### PR TITLE
update upstream (Paper and Tuinity)

### DIFF
--- a/patches/api/0001-Tuinity-API-Changes.patch
+++ b/patches/api/0001-Tuinity-API-Changes.patch
@@ -217,10 +217,10 @@ index f3e27d2d02a9407bb1b091b8c1125ad5abf99e55..b3e7b2a8eaa3980e34bc74a846320b78
           * Sends the component to the player
           *
 diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
-index 064497506e6a5ab89ca43b99968ca79d51d67c46..5848c8c03a1520b95c9f494e0820e075f1757fc6 100644
+index b01cda41fcc14364af6a43165e97a01a5c08d319..b589afda0f759823f8114c82ae1dd2f31e334eed 100644
 --- a/src/main/java/org/bukkit/World.java
 +++ b/src/main/java/org/bukkit/World.java
-@@ -3508,6 +3508,26 @@ public interface World extends PluginMessageRecipient, Metadatable, net.kyori.ad
+@@ -3517,6 +3517,26 @@ public interface World extends PluginMessageRecipient, Metadatable, net.kyori.ad
       * @param viewDistance view distance in [2, 32]
       */
      void setNoTickViewDistance(int viewDistance);

--- a/patches/server/0001-Tuinity-Server-Changes.patch
+++ b/patches/server/0001-Tuinity-Server-Changes.patch
@@ -595,10 +595,10 @@ index 7720578796e28d28e8c0c9aa40155cd205c17d54..e5db29d4cadb5702c7d06b0b6e2d0558
              return Suggestions.empty();
 diff --git a/src/main/java/com/tuinity/tuinity/chunk/PlayerChunkLoader.java b/src/main/java/com/tuinity/tuinity/chunk/PlayerChunkLoader.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..1fbd220b8a2c77ba85e98349b012b293ee7686a8
+index 0000000000000000000000000000000000000000..0d577aa1c7868ce89c3902535adcb554b1f47551
 --- /dev/null
 +++ b/src/main/java/com/tuinity/tuinity/chunk/PlayerChunkLoader.java
-@@ -0,0 +1,955 @@
+@@ -0,0 +1,964 @@
 +package com.tuinity.tuinity.chunk;
 +
 +import com.destroystokyo.paper.util.misc.PlayerAreaMap;
@@ -905,7 +905,7 @@ index 0000000000000000000000000000000000000000..1fbd220b8a2c77ba85e98349b012b293
 +
 +    protected double getTargetSendRatePerPlayer() {
 +        double config = TuinityConfig.playerTargetChunkSendRate;
-+        return config <= 0 ? -config : (int)Math.ceil(-config / MinecraftServer.getServer().getPlayerCount());
++        return config <= 0 ? -config : config / MinecraftServer.getServer().getPlayerCount();
 +    }
 +
 +    public void onChunkPlayerTickReady(final int chunkX, final int chunkZ) {
@@ -974,6 +974,9 @@ index 0000000000000000000000000000000000000000..1fbd220b8a2c77ba85e98349b012b293
 +
 +    public void addPlayer(final EntityPlayer player) {
 +        TickThread.ensureTickThread("Cannot add player async");
++        if (!player.isRealPlayer) {
++            return;
++        }
 +        final PlayerLoaderData data = new PlayerLoaderData(player, this);
 +        if (this.playerMap.putIfAbsent(player, data) == null) {
 +            data.update();
@@ -982,6 +985,9 @@ index 0000000000000000000000000000000000000000..1fbd220b8a2c77ba85e98349b012b293
 +
 +    public void removePlayer(final EntityPlayer player) {
 +        TickThread.ensureTickThread("Cannot remove player async");
++        if (!player.isRealPlayer) {
++            return;
++        }
 +
 +        final PlayerLoaderData loaderData = this.playerMap.remove(player);
 +        if (loaderData == null) {
@@ -1001,6 +1007,9 @@ index 0000000000000000000000000000000000000000..1fbd220b8a2c77ba85e98349b012b293
 +
 +    public void updatePlayer(final EntityPlayer player) {
 +        TickThread.ensureTickThread("Cannot update player async");
++        if (!player.isRealPlayer) {
++            return;
++        }
 +        final PlayerLoaderData loaderData = this.playerMap.get(player);
 +        if (loaderData != null) {
 +            loaderData.update();
@@ -5637,7 +5646,7 @@ index 0000000000000000000000000000000000000000..0e4442a94559346b19a536d35ce5def6
 +}
 diff --git a/src/main/java/com/tuinity/tuinity/config/TuinityConfig.java b/src/main/java/com/tuinity/tuinity/config/TuinityConfig.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..d29b537bbe4f852162b720d6b23b741829af21f9
+index 0000000000000000000000000000000000000000..d0433feeb274f474af04ba1e09f9f75d5b4dcfea
 --- /dev/null
 +++ b/src/main/java/com/tuinity/tuinity/config/TuinityConfig.java
 @@ -0,0 +1,415 @@
@@ -5767,7 +5776,7 @@ index 0000000000000000000000000000000000000000..d29b537bbe4f852162b720d6b23b7418
 +        tickWorldsInParallel = TuinityConfig.getBoolean("tick-worlds-in-parallel", false);
 +        tickThreads = TuinityConfig.getInt("server-tick-threads", 1); // will be 4 in the future
 +    }*/
-+
++    
 +    public static int delayChunkUnloadsBy;
 +
 +    private static void delayChunkUnloadsBy() {
@@ -9915,7 +9924,7 @@ index 7d9a16eb81288b74425319c60525f57c98ad3b69..427413c668865e1660f1d81daf6a3385
      }
  
 diff --git a/src/main/java/net/minecraft/network/NetworkManager.java b/src/main/java/net/minecraft/network/NetworkManager.java
-index f86f430598026a3a7e27fb8d40cfc5fe7b9b845d..e101b1dccec98d5c7b9ee9a2c8aa2e3b911de652 100644
+index f86f430598026a3a7e27fb8d40cfc5fe7b9b845d..0f8cbe1f656b46f71c6494bd2e0057be63017272 100644
 --- a/src/main/java/net/minecraft/network/NetworkManager.java
 +++ b/src/main/java/net/minecraft/network/NetworkManager.java
 @@ -45,6 +45,8 @@ import org.apache.logging.log4j.Logger;
@@ -9966,7 +9975,7 @@ index f86f430598026a3a7e27fb8d40cfc5fe7b9b845d..e101b1dccec98d5c7b9ee9a2c8aa2e3b
 +    // Tuinity start - add pending task queue
 +    private final Queue<Runnable> pendingTasks = new java.util.concurrent.ConcurrentLinkedQueue<>();
 +    public void execute(final Runnable run) {
-+        if (!this.channel.isRegistered()) {
++        if (this.channel == null || !this.channel.isRegistered()) {
 +            run.run();
 +            return;
 +        }
@@ -14659,7 +14668,7 @@ index 185667110cd6f566b23546728d20fc79223f3c92..dc98ef48a664d9ee2a302fff8c611fd1
              throw new IllegalStateException("Protocol error", cryptographyexception);
          }
 diff --git a/src/main/java/net/minecraft/server/network/PlayerConnection.java b/src/main/java/net/minecraft/server/network/PlayerConnection.java
-index a15230235ba0244c42346f51cabb470cb362a455..b7e72fe1cd04219391c75beb7d67a1e32e393a16 100644
+index 4a3f6f26da0d99ee2ff6942c2ff7d0595b53b684..a5871955d487dbf6552d20e5559f2cb1427aeb3e 100644
 --- a/src/main/java/net/minecraft/server/network/PlayerConnection.java
 +++ b/src/main/java/net/minecraft/server/network/PlayerConnection.java
 @@ -568,7 +568,9 @@ public class PlayerConnection implements PacketListenerPlayIn {
@@ -14858,10 +14867,10 @@ index dc362724ea0cc1b2f9d9ceffff483217b4356c40..70fde7bad2e0a6d7432d8509fdb7c46d
                  protected void initChannel(Channel channel) throws Exception {
                      try {
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 92ed4938d5fe6b76e3a9ac5491d6e9c004ade843..ac98a3122ee30971b31761f3bc564b41d5ac879f 100644
+index 2df8e914f66176e22aeddf8b94a83af5ea921d88..499b516330f3f3a48fb64802f2e8c1b7c9684f4d 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
-@@ -178,6 +178,7 @@ public abstract class PlayerList {
+@@ -179,6 +179,7 @@ public abstract class PlayerList {
      abstract public void loadAndSaveFiles(); // Paper - moved from DedicatedPlayerList constructor
  
      public void a(NetworkManager networkmanager, EntityPlayer entityplayer) {
@@ -14869,7 +14878,7 @@ index 92ed4938d5fe6b76e3a9ac5491d6e9c004ade843..ac98a3122ee30971b31761f3bc564b41
          EntityPlayer prev = pendingPlayers.put(entityplayer.getUniqueID(), entityplayer);// Paper
          if (prev != null) {
              disconnectPendingPlayer(prev);
-@@ -268,7 +269,7 @@ public abstract class PlayerList {
+@@ -269,7 +270,7 @@ public abstract class PlayerList {
          boolean flag1 = gamerules.getBoolean(GameRules.REDUCED_DEBUG_INFO);
  
          // Spigot - view distance
@@ -14878,7 +14887,7 @@ index 92ed4938d5fe6b76e3a9ac5491d6e9c004ade843..ac98a3122ee30971b31761f3bc564b41
          entityplayer.getBukkitEntity().sendSupportedChannels(); // CraftBukkit
          playerconnection.sendPacket(new PacketPlayOutCustomPayload(PacketPlayOutCustomPayload.a, (new PacketDataSerializer(Unpooled.buffer())).a(this.getServer().getServerModName())));
          playerconnection.sendPacket(new PacketPlayOutServerDifficulty(worlddata.getDifficulty(), worlddata.isDifficultyLocked()));
-@@ -720,7 +721,7 @@ public abstract class PlayerList {
+@@ -729,7 +730,7 @@ public abstract class PlayerList {
          SocketAddress socketaddress = loginlistener.networkManager.getSocketAddress();
  
          EntityPlayer entity = new EntityPlayer(this.server, this.server.getWorldServer(World.OVERWORLD), gameprofile, new PlayerInteractManager(this.server.getWorldServer(World.OVERWORLD)));
@@ -14887,7 +14896,7 @@ index 92ed4938d5fe6b76e3a9ac5491d6e9c004ade843..ac98a3122ee30971b31761f3bc564b41
          Player player = entity.getBukkitEntity();
          PlayerLoginEvent event = new PlayerLoginEvent(player, hostname, ((java.net.InetSocketAddress) socketaddress).getAddress(), ((java.net.InetSocketAddress) loginlistener.networkManager.getRawAddress()).getAddress());
  
-@@ -940,7 +941,7 @@ public abstract class PlayerList {
+@@ -949,7 +950,7 @@ public abstract class PlayerList {
          // CraftBukkit start
          WorldData worlddata = worldserver1.getWorldData();
          entityplayer1.playerConnection.sendPacket(new PacketPlayOutRespawn(worldserver1.getDimensionManager(), worldserver1.getDimensionKey(), BiomeManager.a(worldserver1.getSeed()), entityplayer1.playerInteractManager.getGameMode(), entityplayer1.playerInteractManager.c(), worldserver1.isDebugWorld(), worldserver1.isFlatWorld(), flag));
@@ -14896,7 +14905,7 @@ index 92ed4938d5fe6b76e3a9ac5491d6e9c004ade843..ac98a3122ee30971b31761f3bc564b41
          entityplayer1.spawnIn(worldserver1);
          entityplayer1.dead = false;
          entityplayer1.playerConnection.teleport(new Location(worldserver1.getWorld(), entityplayer1.locX(), entityplayer1.locY(), entityplayer1.locZ(), entityplayer1.yaw, entityplayer1.pitch));
-@@ -1209,7 +1210,7 @@ public abstract class PlayerList {
+@@ -1218,7 +1219,7 @@ public abstract class PlayerList {
              // Really shouldn't happen...
              backingSet = world != null ? world.players.toArray() : players.toArray();
          } else {
@@ -16951,7 +16960,7 @@ index 03584572fa5bf0d96fc4cecece573547f9c94cea..8bc965a3b3d0d4140c6b94636f0b33b2
                      }
  
 diff --git a/src/main/java/net/minecraft/world/level/World.java b/src/main/java/net/minecraft/world/level/World.java
-index 78dcba08d6d796d5d97c8304bf1f1e7d1e650d5d..c8a5d4972431ce9615312280f36181a2b9645df7 100644
+index 78dcba08d6d796d5d97c8304bf1f1e7d1e650d5d..68fa071fc576f398682ef461df102be432cdcb4c 100644
 --- a/src/main/java/net/minecraft/world/level/World.java
 +++ b/src/main/java/net/minecraft/world/level/World.java
 @@ -154,6 +154,8 @@ public abstract class World implements GeneratorAccess, AutoCloseable {
@@ -17074,6 +17083,15 @@ index 78dcba08d6d796d5d97c8304bf1f1e7d1e650d5d..c8a5d4972431ce9615312280f36181a2
 +            } else if ((i & 2) != 0 && (!this.isClientSide || (i & 4) == 0) && (this.isClientSide || chunk == null || ((WorldServer)this).getChunkProvider().playerChunkMap.playerChunkManager.broadcastMap.getObjectsInRange(MCUtil.getCoordinateKey(blockposition)) != null)) { // Tuinity - replace old player chunk management
                  ((WorldServer)this).getChunkProvider().flagDirty(blockposition);
                  // Paper end - per player view distance
+             }
+@@ -895,7 +968,7 @@ public abstract class World implements GeneratorAccess, AutoCloseable {
+                 //this.tileEntityList.remove(tileentity); // Paper - remove unused list
+                 // Paper - prevent double chunk lookups
+                 Chunk chunk; if ((chunk = this.getChunkIfLoaded(tileentity.getPosition())) != null) { // inlined contents of this.isLoaded(BlockPosition). Reuse the returned chunk instead of looking it up again
+-                    chunk.removeTileEntity(tileentity.getPosition());
++                    chunk.removeTileEntity(tileentity.getPosition(), tileentity); // Tuinity - make sure we remove the correct TE
+                 }
+                 // Paper end
              }
 @@ -955,6 +1028,7 @@ public abstract class World implements GeneratorAccess, AutoCloseable {
              return;
@@ -17730,7 +17748,7 @@ index 3c25021835d6d8fd112fc89636616bfd744e7f1a..aa49565cd364db3781a110ee138ee1a4
          return this.j.d();
      }
 diff --git a/src/main/java/net/minecraft/world/level/chunk/Chunk.java b/src/main/java/net/minecraft/world/level/chunk/Chunk.java
-index 34a9f7b2f998f77b1279516cd09397ab6c2ac1cc..259d4ac89e84fd334ff65ea8a606e1fc50cc882b 100644
+index 34a9f7b2f998f77b1279516cd09397ab6c2ac1cc..ffef28f9fa82a6961ef6db5f6732cfee4352ee01 100644
 --- a/src/main/java/net/minecraft/world/level/chunk/Chunk.java
 +++ b/src/main/java/net/minecraft/world/level/chunk/Chunk.java
 @@ -137,6 +137,158 @@ public class Chunk implements IChunkAccess {
@@ -17984,7 +18002,28 @@ index 34a9f7b2f998f77b1279516cd09397ab6c2ac1cc..259d4ac89e84fd334ff65ea8a606e1fc
              return;
          }
          if (entity instanceof EntityItem) {
-@@ -858,6 +995,7 @@ public class Chunk implements IChunkAccess {
+@@ -819,10 +956,18 @@ public class Chunk implements IChunkAccess {
+ 
+     @Override
+     public void removeTileEntity(BlockPosition blockposition) {
++        // Tuinity start - make sure we remove the correct TE
++        this.removeTileEntity(blockposition, null);
++    }
++    public void removeTileEntity(BlockPosition blockposition, TileEntity match) {
++        // Tuinity end - make sure we remove the correct TE
+         if (this.loaded || this.world.s_()) {
+-            TileEntity tileentity = (TileEntity) this.tileEntities.remove(blockposition);
++            // Tuinity start - make sure we remove the correct TE
++            TileEntity tileentity = (TileEntity) this.tileEntities.get(blockposition);
+ 
+-            if (tileentity != null) {
++            if (tileentity != null && (match == null || match == tileentity)) {
++                this.tileEntities.remove(blockposition);
++                // Tuinity end - make sure we remove the correct TE
+                 tileentity.al_();
+             }
+         }
+@@ -858,6 +1003,7 @@ public class Chunk implements IChunkAccess {
          // Paper end - neighbour cache
          org.bukkit.Server server = this.world.getServer();
          ((WorldServer)this.world).getChunkProvider().addLoadedChunk(this); // Paper
@@ -17992,7 +18031,7 @@ index 34a9f7b2f998f77b1279516cd09397ab6c2ac1cc..259d4ac89e84fd334ff65ea8a606e1fc
          if (server != null) {
              /*
               * If it's a new world, the first few chunks are generated inside
-@@ -922,116 +1060,18 @@ public class Chunk implements IChunkAccess {
+@@ -922,116 +1068,18 @@ public class Chunk implements IChunkAccess {
      }
  
      public void a(@Nullable Entity entity, AxisAlignedBB axisalignedbb, List<Entity> list, @Nullable Predicate<? super Entity> predicate) {
@@ -20375,7 +20414,7 @@ index 03b8d67a5f0088c0254b2099f27e8dcae32a6221..fd3333fef4112e6469ccd316ba2c8292
          public void restart() {
              org.spigotmc.RestartCommand.restart();
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 16567619d7ca84a997ef46417d72f92e6db6993d..292bd2187eb08fe535a8c1f8047be2bb29f55c53 100644
+index e739b4f8a7b8785ceb11c553bd27e2fe0e64a4bb..b393490231ea00af15d883336a07de6cca642195 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 @@ -342,6 +342,14 @@ public class CraftWorld implements World {
@@ -20448,7 +20487,7 @@ index 16567619d7ca84a997ef46417d72f92e6db6993d..292bd2187eb08fe535a8c1f8047be2bb
      @Override
      public boolean isChunkForceLoaded(int x, int z) {
          return getHandle().getForceLoadedChunks().contains(ChunkCoordIntPair.pair(x, z));
-@@ -2581,7 +2607,7 @@ public class CraftWorld implements World {
+@@ -2586,7 +2612,7 @@ public class CraftWorld implements World {
          }
          return this.world.getChunkProvider().getChunkAtAsynchronously(x, z, gen, urgent).thenComposeAsync((either) -> {
              net.minecraft.world.level.chunk.Chunk chunk = (net.minecraft.world.level.chunk.Chunk) either.left().orElse(null);
@@ -20457,7 +20496,7 @@ index 16567619d7ca84a997ef46417d72f92e6db6993d..292bd2187eb08fe535a8c1f8047be2bb
              return CompletableFuture.completedFuture(chunk == null ? null : chunk.getBukkitChunk());
          }, net.minecraft.server.MinecraftServer.getServer());
      }
-@@ -2606,14 +2632,14 @@ public class CraftWorld implements World {
+@@ -2611,14 +2637,14 @@ public class CraftWorld implements World {
              throw new IllegalArgumentException("View distance " + viewDistance + " is out of range of [2, 32]");
          }
          PlayerChunkMap chunkMap = getHandle().getChunkProvider().playerChunkMap;
@@ -20474,7 +20513,7 @@ index 16567619d7ca84a997ef46417d72f92e6db6993d..292bd2187eb08fe535a8c1f8047be2bb
      }
  
      @Override
-@@ -2622,11 +2648,22 @@ public class CraftWorld implements World {
+@@ -2627,11 +2653,22 @@ public class CraftWorld implements World {
              throw new IllegalArgumentException("View distance " + viewDistance + " is out of range of [2, 32]");
          }
          PlayerChunkMap chunkMap = getHandle().getChunkProvider().playerChunkMap;

--- a/patches/server/0002-Airplane-Server-Changes.patch
+++ b/patches/server/0002-Airplane-Server-Changes.patch
@@ -2870,7 +2870,7 @@ index acacbf9617f99b97fc7fd2ba718775e1b3e429e9..967ae0212028d57d366497f7f25c6177
          // Paper end
      }
 diff --git a/src/main/java/net/minecraft/world/level/World.java b/src/main/java/net/minecraft/world/level/World.java
-index c8a5d4972431ce9615312280f36181a2b9645df7..e3f1f20608cab7067674b2cdd2759a34902b6626 100644
+index 68fa071fc576f398682ef461df102be432cdcb4c..4608846801fe1de8660ce586453ef4964dfbe2b0 100644
 --- a/src/main/java/net/minecraft/world/level/World.java
 +++ b/src/main/java/net/minecraft/world/level/World.java
 @@ -69,6 +69,8 @@ import net.minecraft.world.level.saveddata.maps.WorldMap;
@@ -3044,7 +3044,7 @@ index 712596420af83e6e1b9d147ae2fd8d8a1f36e1b9..9c29fa3efac7e16df81b8a44934e3286
                      if (worldserver.getType(blockposition1).a(Blocks.DIRT) && c(iblockdata1, (IWorldReader) worldserver, blockposition1)) {
                          org.bukkit.craftbukkit.event.CraftEventFactory.handleBlockSpreadEvent(worldserver, blockposition, blockposition1, (IBlockData) iblockdata1.set(BlockDirtSnowSpreadable.a, worldserver.getType(blockposition1.up()).a(Blocks.SNOW))); // CraftBukkit
 diff --git a/src/main/java/net/minecraft/world/level/chunk/Chunk.java b/src/main/java/net/minecraft/world/level/chunk/Chunk.java
-index 259d4ac89e84fd334ff65ea8a606e1fc50cc882b..4f5f9eb110cf71a966d1365c7813ba55b5127890 100644
+index ffef28f9fa82a6961ef6db5f6732cfee4352ee01..506c75013831a01e323a43ac94986600b8433e11 100644
 --- a/src/main/java/net/minecraft/world/level/chunk/Chunk.java
 +++ b/src/main/java/net/minecraft/world/level/chunk/Chunk.java
 @@ -99,6 +99,38 @@ public class Chunk implements IChunkAccess {

--- a/patches/server/0004-Purpur-config-files.patch
+++ b/patches/server/0004-Purpur-config-files.patch
@@ -65,7 +65,7 @@ index 24a46ad36613faa5f5a1a12b70f7af886e1608ae..28d47ef97939309ce26b6e4cae14925b
          // Paper end
          com.tuinity.tuinity.config.TuinityConfig.init((java.io.File) options.valueOf("tuinity-settings")); // Tuinity - Server Config
 diff --git a/src/main/java/net/minecraft/world/level/World.java b/src/main/java/net/minecraft/world/level/World.java
-index e3f1f20608cab7067674b2cdd2759a34902b6626..cef8e9b379c4205386d1001e86abc7dcb0b18eb6 100644
+index 4608846801fe1de8660ce586453ef4964dfbe2b0..79ee0efde401f61172a7fb17c56acede378b7245 100644
 --- a/src/main/java/net/minecraft/world/level/World.java
 +++ b/src/main/java/net/minecraft/world/level/World.java
 @@ -157,6 +157,7 @@ public abstract class World implements GeneratorAccess, AutoCloseable {

--- a/patches/server/0009-AFK-API.patch
+++ b/patches/server/0009-AFK-API.patch
@@ -86,7 +86,7 @@ index 9d97e2ea5c207c42f1cc9aa14bc87dc8e0a1bb1e..984a90a0a69f60315536d60eff597f65
                  } else if (entityplayer.isSleeping()) {
                      ++j;
 diff --git a/src/main/java/net/minecraft/server/network/PlayerConnection.java b/src/main/java/net/minecraft/server/network/PlayerConnection.java
-index b7e72fe1cd04219391c75beb7d67a1e32e393a16..789cf1652fec8346c1ea3ca47d9ac43c0765528a 100644
+index a5871955d487dbf6552d20e5559f2cb1427aeb3e..9603503f8959379c3b6e30b22946fa2b6b100504 100644
 --- a/src/main/java/net/minecraft/server/network/PlayerConnection.java
 +++ b/src/main/java/net/minecraft/server/network/PlayerConnection.java
 @@ -397,6 +397,12 @@ public class PlayerConnection implements PacketListenerPlayIn {

--- a/patches/server/0017-Player-invulnerabilities.patch
+++ b/patches/server/0017-Player-invulnerabilities.patch
@@ -67,7 +67,7 @@ index f30dcbd26ed56ba8f1a99260722a0b395c220954..7cd1ae92768164b657af9febe9b4feb7
      public Scoreboard getScoreboard() {
          return getBukkitEntity().getScoreboard().getHandle();
 diff --git a/src/main/java/net/minecraft/server/network/PlayerConnection.java b/src/main/java/net/minecraft/server/network/PlayerConnection.java
-index 789cf1652fec8346c1ea3ca47d9ac43c0765528a..a056adcae8c4c46ede25fdd33aeab616a1af3a76 100644
+index 9603503f8959379c3b6e30b22946fa2b6b100504..016e4c92545ee6effe0311ad7651255cb88bd9f2 100644
 --- a/src/main/java/net/minecraft/server/network/PlayerConnection.java
 +++ b/src/main/java/net/minecraft/server/network/PlayerConnection.java
 @@ -1882,6 +1882,7 @@ public class PlayerConnection implements PacketListenerPlayIn {
@@ -79,10 +79,10 @@ index 789cf1652fec8346c1ea3ca47d9ac43c0765528a..a056adcae8c4c46ede25fdd33aeab616
          this.server.getPluginManager().callEvent(new PlayerResourcePackStatusEvent(getPlayer(), packStatus));
          // Paper end
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index ac98a3122ee30971b31761f3bc564b41d5ac879f..49acc6e43748a2d2a68f1b134421831b2feedd7b 100644
+index 499b516330f3f3a48fb64802f2e8c1b7c9684f4d..25983bce99fa3c2b5a571499ced145be0934091f 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
-@@ -998,6 +998,8 @@ public abstract class PlayerList {
+@@ -1007,6 +1007,8 @@ public abstract class PlayerList {
          }
          // Paper end
  

--- a/patches/server/0020-Alternative-Keepalive-Handling.patch
+++ b/patches/server/0020-Alternative-Keepalive-Handling.patch
@@ -17,7 +17,7 @@ index b4c37287362907b8507d156b978ba5b9d961bb7b..9e6e6636539702507abb78515e002819
          return this.a;
      }
 diff --git a/src/main/java/net/minecraft/server/network/PlayerConnection.java b/src/main/java/net/minecraft/server/network/PlayerConnection.java
-index a056adcae8c4c46ede25fdd33aeab616a1af3a76..68200fe85fc4e66bb58dd35df306ba37604b6b94 100644
+index 016e4c92545ee6effe0311ad7651255cb88bd9f2..5173affbc42ca00305557b53f606f1d9eb78d468 100644
 --- a/src/main/java/net/minecraft/server/network/PlayerConnection.java
 +++ b/src/main/java/net/minecraft/server/network/PlayerConnection.java
 @@ -231,6 +231,7 @@ public class PlayerConnection implements PacketListenerPlayIn {

--- a/patches/server/0046-Signs-allow-color-codes.patch
+++ b/patches/server/0046-Signs-allow-color-codes.patch
@@ -17,7 +17,7 @@ index 7cd1ae92768164b657af9febe9b4feb7fd02f55a..fe583fbc58309564d35d4cdd56fafc4d
          this.playerConnection.sendPacket(new PacketPlayOutOpenSignEditor(tileentitysign.getPosition()));
      }
 diff --git a/src/main/java/net/minecraft/server/network/PlayerConnection.java b/src/main/java/net/minecraft/server/network/PlayerConnection.java
-index 68200fe85fc4e66bb58dd35df306ba37604b6b94..bbb3b44bdceb8fb0363f771b8cf1b8245b5c8d3d 100644
+index 5173affbc42ca00305557b53f606f1d9eb78d468..5f91259b305a48fd09a156799808c25561788882 100644
 --- a/src/main/java/net/minecraft/server/network/PlayerConnection.java
 +++ b/src/main/java/net/minecraft/server/network/PlayerConnection.java
 @@ -3047,6 +3047,15 @@ public class PlayerConnection implements PacketListenerPlayIn {

--- a/patches/server/0055-Add-permission-for-F3-N-debug.patch
+++ b/patches/server/0055-Add-permission-for-F3-N-debug.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add permission for F3+N debug
 
 
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 49acc6e43748a2d2a68f1b134421831b2feedd7b..54e009ee763a689125eb521f9144951aac53a4c0 100644
+index 25983bce99fa3c2b5a571499ced145be0934091f..aceb83c2f60ee90b8e0369a076b7fa3093dfa821 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
-@@ -1157,6 +1157,7 @@ public abstract class PlayerList {
+@@ -1166,6 +1166,7 @@ public abstract class PlayerList {
              } else {
                  b0 = (byte) (24 + i);
              }

--- a/patches/server/0080-Add-phantom-spawning-options.patch
+++ b/patches/server/0080-Add-phantom-spawning-options.patch
@@ -61,7 +61,7 @@ index d98526785ff2fa3b72e8ffffcb89a57a2203a5c8..7859d84471436b427138593776ebd30a
          return iblockdata.r(iblockaccess, blockposition) ? false : (iblockdata.isPowerSource() ? false : (!fluid.isEmpty() ? false : (iblockdata.a((Tag) TagsBlock.PREVENT_MOB_SPAWNING_INSIDE) ? false : !entitytypes.a(iblockdata))));
      }
 diff --git a/src/main/java/net/minecraft/world/level/World.java b/src/main/java/net/minecraft/world/level/World.java
-index cef8e9b379c4205386d1001e86abc7dcb0b18eb6..4fa0f6ce7f8e6f5fba68d66a2c81ad4a53ca2146 100644
+index 79ee0efde401f61172a7fb17c56acede378b7245..d1c1a5902ee3aa70dc7ebf4f803d10a959fff1d2 100644
 --- a/src/main/java/net/minecraft/world/level/World.java
 +++ b/src/main/java/net/minecraft/world/level/World.java
 @@ -1749,6 +1749,7 @@ public abstract class World implements GeneratorAccess, AutoCloseable {

--- a/patches/server/0083-Add-allow-water-in-end-world-option.patch
+++ b/patches/server/0083-Add-allow-water-in-end-world-option.patch
@@ -27,7 +27,7 @@ index d126f668828e0788e369294c0b376ef52b344f2c..154a76b1b77a97bdf65153250c41275f
  
                  return true;
 diff --git a/src/main/java/net/minecraft/world/level/World.java b/src/main/java/net/minecraft/world/level/World.java
-index 4fa0f6ce7f8e6f5fba68d66a2c81ad4a53ca2146..93cbdcd641762e3ab00258fd94ac381ebe47fb79 100644
+index d1c1a5902ee3aa70dc7ebf4f803d10a959fff1d2..771c1f027bb64b36903a352b6a837e6e8bf1b7d4 100644
 --- a/src/main/java/net/minecraft/world/level/World.java
 +++ b/src/main/java/net/minecraft/world/level/World.java
 @@ -1824,4 +1824,14 @@ public abstract class World implements GeneratorAccess, AutoCloseable {

--- a/patches/server/0084-Allow-color-codes-in-books.patch
+++ b/patches/server/0084-Allow-color-codes-in-books.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Allow color codes in books
 
 
 diff --git a/src/main/java/net/minecraft/server/network/PlayerConnection.java b/src/main/java/net/minecraft/server/network/PlayerConnection.java
-index bbb3b44bdceb8fb0363f771b8cf1b8245b5c8d3d..c2d9b76a915bbfaa3382512b3f9ab906e058c0f9 100644
+index 5f91259b305a48fd09a156799808c25561788882..72dda95171cf7d4632256b4d661338209d2adfb5 100644
 --- a/src/main/java/net/minecraft/server/network/PlayerConnection.java
 +++ b/src/main/java/net/minecraft/server/network/PlayerConnection.java
 @@ -1203,7 +1203,8 @@ public class PlayerConnection implements PacketListenerPlayIn {

--- a/patches/server/0085-Entity-lifespan.patch
+++ b/patches/server/0085-Entity-lifespan.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Entity lifespan
 
 
 diff --git a/src/main/java/net/minecraft/server/network/PlayerConnection.java b/src/main/java/net/minecraft/server/network/PlayerConnection.java
-index c2d9b76a915bbfaa3382512b3f9ab906e058c0f9..319d9d2ba8ce3b5311746938b06999702847ce0b 100644
+index 72dda95171cf7d4632256b4d661338209d2adfb5..c5549b74a3875c0fa1bfe8f270b25b59317073a3 100644
 --- a/src/main/java/net/minecraft/server/network/PlayerConnection.java
 +++ b/src/main/java/net/minecraft/server/network/PlayerConnection.java
 @@ -2443,6 +2443,7 @@ public class PlayerConnection implements PacketListenerPlayIn {

--- a/patches/server/0094-Populator-seed-controls.patch
+++ b/patches/server/0094-Populator-seed-controls.patch
@@ -18,7 +18,7 @@ index 5e672a0660d0aceffcdb26d185590ca18aa4f023..4b171a2a60e24947e884f8988920f335
              }
              final Object val = config.get(key);
 diff --git a/src/main/java/com/tuinity/tuinity/config/TuinityConfig.java b/src/main/java/com/tuinity/tuinity/config/TuinityConfig.java
-index d29b537bbe4f852162b720d6b23b741829af21f9..c3669383050241df97e25c89d80720ad446c690d 100644
+index d0433feeb274f474af04ba1e09f9f75d5b4dcfea..ea0a292c93bd7d777a5979f930822a8912c2f8d0 100644
 --- a/src/main/java/com/tuinity/tuinity/config/TuinityConfig.java
 +++ b/src/main/java/com/tuinity/tuinity/config/TuinityConfig.java
 @@ -1,5 +1,6 @@

--- a/patches/server/0103-Ridables.patch
+++ b/patches/server/0103-Ridables.patch
@@ -100,7 +100,7 @@ index 345718ed5b30a2ba1ee6082b571e5771112e381b..88741bec1a16b14c6e80737328411c5d
          return new Throwable(entity + " Added to world at " + new java.util.Date());
      }
 diff --git a/src/main/java/net/minecraft/server/network/PlayerConnection.java b/src/main/java/net/minecraft/server/network/PlayerConnection.java
-index 319d9d2ba8ce3b5311746938b06999702847ce0b..8d53548bc0d8076d3831b72673ab5412a77919a4 100644
+index c5549b74a3875c0fa1bfe8f270b25b59317073a3..d5c38de84787089466d73dd5400f3276470716be 100644
 --- a/src/main/java/net/minecraft/server/network/PlayerConnection.java
 +++ b/src/main/java/net/minecraft/server/network/PlayerConnection.java
 @@ -2452,6 +2452,8 @@ public class PlayerConnection implements PacketListenerPlayIn {
@@ -5475,7 +5475,7 @@ index 96efd974f1eb9c1e7c70e576e51ed69e15aacb99..fc86ef53c48503139667f7703019a07c
  
      default int getHeight() {
 diff --git a/src/main/java/net/minecraft/world/level/World.java b/src/main/java/net/minecraft/world/level/World.java
-index 93cbdcd641762e3ab00258fd94ac381ebe47fb79..c75b1b1e8d99157336065f561d40ac803239c6b7 100644
+index 771c1f027bb64b36903a352b6a837e6e8bf1b7d4..8264ed9c44ae0608c4bb3102d4b8acc849cc9609 100644
 --- a/src/main/java/net/minecraft/world/level/World.java
 +++ b/src/main/java/net/minecraft/world/level/World.java
 @@ -1833,5 +1833,10 @@ public abstract class World implements GeneratorAccess, AutoCloseable {

--- a/patches/server/0109-Allow-toggling-special-MobSpawners-per-world.patch
+++ b/patches/server/0109-Allow-toggling-special-MobSpawners-per-world.patch
@@ -93,7 +93,7 @@ index 7c8a2151be8a0f48cba1c15d231d5dbdb500b4d6..361771fc4fcf16b1b013c55073401953
              if (SpawnerCreature.a(EntityPositionTypes.Surface.ON_GROUND, iworldreader, blockposition2, EntityTypes.WANDERING_TRADER)) {
                  blockposition1 = blockposition2;
 diff --git a/src/main/java/net/minecraft/world/level/World.java b/src/main/java/net/minecraft/world/level/World.java
-index c75b1b1e8d99157336065f561d40ac803239c6b7..06ecb1ec2b92f0978c57de6353f63a02e6e363da 100644
+index 8264ed9c44ae0608c4bb3102d4b8acc849cc9609..6bdd1011b1b56d4697297241b0a3e223fa6e5a1a 100644
 --- a/src/main/java/net/minecraft/world/level/World.java
 +++ b/src/main/java/net/minecraft/world/level/World.java
 @@ -250,7 +250,7 @@ public abstract class World implements GeneratorAccess, AutoCloseable {

--- a/patches/server/0124-Add-adjustable-breeding-cooldown-to-config.patch
+++ b/patches/server/0124-Add-adjustable-breeding-cooldown-to-config.patch
@@ -33,7 +33,7 @@ index 28dd42921961c6a47f2d85a5f93b8298f2c228d3..6ae5fafd379863bf23df3580d3dbc7a5
              int experience = this.getRandom().nextInt(7) + 1;
              org.bukkit.event.entity.EntityBreedEvent entityBreedEvent = org.bukkit.craftbukkit.event.CraftEventFactory.callEntityBreedEvent(entityageable, this, entityanimal, entityplayer, this.breedItem, experience);
 diff --git a/src/main/java/net/minecraft/world/level/World.java b/src/main/java/net/minecraft/world/level/World.java
-index 06ecb1ec2b92f0978c57de6353f63a02e6e363da..266240b2fa9f22c5bff094fdb003a73a50ef1a81 100644
+index 6bdd1011b1b56d4697297241b0a3e223fa6e5a1a..b2c39a5e3ed2306d317837ae4e4fcc533d8afd2a 100644
 --- a/src/main/java/net/minecraft/world/level/World.java
 +++ b/src/main/java/net/minecraft/world/level/World.java
 @@ -41,6 +41,7 @@ import net.minecraft.world.DifficultyDamageScaler;

--- a/patches/server/0136-Origami-Fix-ProtocolLib-issues-on-Java-15.patch
+++ b/patches/server/0136-Origami-Fix-ProtocolLib-issues-on-Java-15.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Origami - Fix ProtocolLib issues on Java 15
 
 
 diff --git a/src/main/java/net/minecraft/network/NetworkManager.java b/src/main/java/net/minecraft/network/NetworkManager.java
-index e101b1dccec98d5c7b9ee9a2c8aa2e3b911de652..2214b116d1e548eca3c2e70e8b23d7c7913c361d 100644
+index 0f8cbe1f656b46f71c6494bd2e0057be63017272..f46488155d8bd07719a282e4a1027562973dbef6 100644
 --- a/src/main/java/net/minecraft/network/NetworkManager.java
 +++ b/src/main/java/net/minecraft/network/NetworkManager.java
 @@ -435,9 +435,9 @@ public class NetworkManager extends SimpleChannelInboundHandler<Packet<?>> {

--- a/patches/server/0147-Spread-out-and-optimise-player-list-ticks.patch
+++ b/patches/server/0147-Spread-out-and-optimise-player-list-ticks.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Spread out and optimise player list ticks
 
 
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 54e009ee763a689125eb521f9144951aac53a4c0..fbc8f7746fc92def73c244b3c12da990741d4bd5 100644
+index aceb83c2f60ee90b8e0369a076b7fa3093dfa821..e8270ad5dc27430bdbc89299a3ff8d8d4249dc4c 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
-@@ -150,7 +150,7 @@ public abstract class PlayerList {
+@@ -151,7 +151,7 @@ public abstract class PlayerList {
      private int viewDistance;
      private EnumGamemode u;
      private boolean v;
@@ -17,7 +17,7 @@ index 54e009ee763a689125eb521f9144951aac53a4c0..fbc8f7746fc92def73c244b3c12da990
  
      // CraftBukkit start
      private CraftServer cserver;
-@@ -1012,22 +1012,23 @@ public abstract class PlayerList {
+@@ -1021,22 +1021,23 @@ public abstract class PlayerList {
      }
  
      public void tick() {

--- a/patches/server/0153-Implement-TPSBar.patch
+++ b/patches/server/0153-Implement-TPSBar.patch
@@ -37,10 +37,10 @@ index 5de12553875af626fa597ca440e52682624e35c8..e8146dad220330bdcc46e563172b40a6
          this.isRestarting = isRestarting;
          this.hasLoggedStop = true; // Paper
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index fbc8f7746fc92def73c244b3c12da990741d4bd5..3b70d3e3cf7cb17c075f8b758ba7967f99325223 100644
+index e8270ad5dc27430bdbc89299a3ff8d8d4249dc4c..8b76e61228c8c766aaef9afe3fc81fc17a10d72c 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
-@@ -597,6 +597,8 @@ public abstract class PlayerList {
+@@ -598,6 +598,8 @@ public abstract class PlayerList {
          if (entityplayer.didPlayerJoinEvent) cserver.getPluginManager().callEvent(playerQuitEvent); // Paper - if we disconnected before join ever fired, don't fire quit
          entityplayer.getBukkitEntity().disconnect(playerQuitEvent.getQuitMessage());
  

--- a/patches/server/0155-PlayerBookTooLargeEvent.patch
+++ b/patches/server/0155-PlayerBookTooLargeEvent.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] PlayerBookTooLargeEvent
 
 
 diff --git a/src/main/java/net/minecraft/server/network/PlayerConnection.java b/src/main/java/net/minecraft/server/network/PlayerConnection.java
-index 8d53548bc0d8076d3831b72673ab5412a77919a4..b81b7a4f7debdb77a9b8906e3d87420be51b8e62 100644
+index d5c38de84787089466d73dd5400f3276470716be..42f1216db0832b8606e57fc762d5e016450eaf5b 100644
 --- a/src/main/java/net/minecraft/server/network/PlayerConnection.java
 +++ b/src/main/java/net/minecraft/server/network/PlayerConnection.java
 @@ -1115,6 +1115,7 @@ public class PlayerConnection implements PacketListenerPlayIn {

--- a/patches/server/0166-Fix-PlayerEditBookEvent-not-saving-new-book.patch
+++ b/patches/server/0166-Fix-PlayerEditBookEvent-not-saving-new-book.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Fix PlayerEditBookEvent not saving new book
 
 
 diff --git a/src/main/java/net/minecraft/server/network/PlayerConnection.java b/src/main/java/net/minecraft/server/network/PlayerConnection.java
-index b81b7a4f7debdb77a9b8906e3d87420be51b8e62..c7c26cd1b99c911efd12e325e0ca09d9ac98c6f4 100644
+index 42f1216db0832b8606e57fc762d5e016450eaf5b..c93fc03d49c467a6db2e55f4999edad3452136a4 100644
 --- a/src/main/java/net/minecraft/server/network/PlayerConnection.java
 +++ b/src/main/java/net/minecraft/server/network/PlayerConnection.java
 @@ -1210,7 +1210,7 @@ public class PlayerConnection implements PacketListenerPlayIn {

--- a/patches/server/0174-Dont-run-with-scissors.patch
+++ b/patches/server/0174-Dont-run-with-scissors.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Dont run with scissors!
 
 
 diff --git a/src/main/java/net/minecraft/server/network/PlayerConnection.java b/src/main/java/net/minecraft/server/network/PlayerConnection.java
-index c7c26cd1b99c911efd12e325e0ca09d9ac98c6f4..bdcc8ced52a858d2dd0bbfaab5a21197327d4dda 100644
+index c93fc03d49c467a6db2e55f4999edad3452136a4..8359ccf316d292d81c56600887178cea6e33f270 100644
 --- a/src/main/java/net/minecraft/server/network/PlayerConnection.java
 +++ b/src/main/java/net/minecraft/server/network/PlayerConnection.java
 @@ -1533,6 +1533,12 @@ public class PlayerConnection implements PacketListenerPlayIn {


### PR DESCRIPTION
Upstream has released updates that appear to apply and compile correctly

Paper Changes:
f7b4abb25 [Auto] Updated Upstream (Bukkit/CraftBukkit)
8b47131da Optimize short circuit evaluation of sign check (#5348)
1a2fd12a5 Drop carried item when player has disconnected (#5036) (#5166)
68af93524 Use PaperAdventure.PLAIN instead of PlainComponentSerializer.plain() for AdventureComponent#getString (#5414)

Tuinity Changes:
2c1662918 Fix NPE in NetworkManager#execute
1b0d7833d Updated Upstream (Paper)
2a6cd81ca Make sure to remove correct TE during TE tick
a9599d80d Fix incorrect parsing of positive target-send-rate
ab00f31c4 Do not load chunks around fake players
94f025a2e Updated Upstream (Paper)