### PR TITLE
update upstream from paper and bukkit

### DIFF
--- a/patches/server/0001-Tuinity-Server-Changes.patch
+++ b/patches/server/0001-Tuinity-Server-Changes.patch
@@ -10913,7 +10913,7 @@ index 1d72af9cace7aa8f1d20c7c1c5be621f533e2dad..b7399d17dd64ca8b1f1fab405cb0ac91
              worldData.addProperty("keep-spawn-loaded-range", world.paperConfig.keepLoadedRange);
              worldData.addProperty("visible-chunk-count", visibleChunks.size());
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 0db00322ebf600245bf9311e547c8c743a60a173..02d8a8f13d81c47316f704fb700afd0214a5f546 100644
+index 8ee622108cebff2bba8a44fb255a3b6c03ed0220..7b0b416c73c8914f3c8c570f2020490ef2babf64 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -267,6 +267,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
@@ -10924,7 +10924,7 @@ index 0db00322ebf600245bf9311e547c8c743a60a173..02d8a8f13d81c47316f704fb700afd02
      public java.util.Queue<Runnable> processQueue = new java.util.concurrent.ConcurrentLinkedQueue<Runnable>();
      public int autosavePeriod;
      public boolean serverAutoSave = false; // Paper
-@@ -867,10 +868,11 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -877,10 +878,11 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
          org.spigotmc.WatchdogThread.doStop(); // Paper
          if (!isMainThread()) {
              MinecraftServer.LOGGER.info("Stopping main thread (Ignore any thread death message you see! - DO NOT REPORT THREAD DEATH TO PAPER)");
@@ -10937,7 +10937,7 @@ index 0db00322ebf600245bf9311e547c8c743a60a173..02d8a8f13d81c47316f704fb700afd02
                  } catch (InterruptedException e) {}
              }
              // We've just obliterated the main thread, this will prevent stop from dying when removing players
-@@ -1071,6 +1073,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -1081,6 +1083,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
                  // Paper end
  
                  PaperJvmChecker.checkJvm(); // Paper jvm version nag
@@ -10945,7 +10945,7 @@ index 0db00322ebf600245bf9311e547c8c743a60a173..02d8a8f13d81c47316f704fb700afd02
                  org.spigotmc.WatchdogThread.tick(); // Paper
                  org.spigotmc.WatchdogThread.hasStarted = true; // Paper
                  Arrays.fill( recentTps, 20 );
-@@ -1088,6 +1091,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -1098,6 +1101,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
                          this.lastOverloadTime = this.nextTick;
                      }
  
@@ -10953,7 +10953,7 @@ index 0db00322ebf600245bf9311e547c8c743a60a173..02d8a8f13d81c47316f704fb700afd02
                      if ( ++MinecraftServer.currentTick % SAMPLE_INTERVAL == 0 )
                      {
                          final long diff = curTime - tickSection;
-@@ -1102,7 +1106,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -1112,7 +1116,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
                          // Paper end
                          tickSection = curTime;
                      }
@@ -10962,7 +10962,7 @@ index 0db00322ebf600245bf9311e547c8c743a60a173..02d8a8f13d81c47316f704fb700afd02
                      // Spigot end
  
                      //MinecraftServer.currentTick = (int) (System.currentTimeMillis() / 50); // CraftBukkit // Paper - don't overwrite current tick time
-@@ -1195,6 +1199,76 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -1205,6 +1209,76 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
      }
      // Paper end
  
@@ -11039,7 +11039,7 @@ index 0db00322ebf600245bf9311e547c8c743a60a173..02d8a8f13d81c47316f704fb700afd02
      private void executeModerately() {
          this.executeAll();
          java.util.concurrent.locks.LockSupport.parkNanos("executing tasks", 1000L);
-@@ -1208,22 +1282,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -1218,22 +1292,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
          });
      }
  
@@ -11063,7 +11063,7 @@ index 0db00322ebf600245bf9311e547c8c743a60a173..02d8a8f13d81c47316f704fb700afd02
  
      @Override
      public TickTask postToMainThread(Runnable runnable) {
-@@ -1250,6 +1309,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -1260,6 +1319,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
  
      private boolean bb() {
          if (super.executeNext()) {
@@ -11071,7 +11071,7 @@ index 0db00322ebf600245bf9311e547c8c743a60a173..02d8a8f13d81c47316f704fb700afd02
              return true;
          } else {
              if (this.canSleepForTick()) {
-@@ -1317,7 +1377,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -1327,7 +1387,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
          // Paper start - move oversleep into full server tick
          isOversleep = true;MinecraftTimings.serverOversleep.startTiming();
          this.awaitTasks(() -> {
@@ -11080,7 +11080,7 @@ index 0db00322ebf600245bf9311e547c8c743a60a173..02d8a8f13d81c47316f704fb700afd02
              return !this.canOversleep();
          });
          isOversleep = false;MinecraftTimings.serverOversleep.stopTiming();
-@@ -1382,6 +1442,8 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -1392,6 +1452,8 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
          }
          // Paper end
  
@@ -11089,7 +11089,7 @@ index 0db00322ebf600245bf9311e547c8c743a60a173..02d8a8f13d81c47316f704fb700afd02
          // Paper start
          long endTime = System.nanoTime();
          long remaining = (TICK_TIME - (endTime - lastTick)) - catchupTime;
-@@ -1408,16 +1470,16 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -1418,16 +1480,16 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
      }
  
      protected void b(BooleanSupplier booleansupplier) {
@@ -11109,7 +11109,7 @@ index 0db00322ebf600245bf9311e547c8c743a60a173..02d8a8f13d81c47316f704fb700afd02
          this.methodProfiler.exitEnter("levels");
          Iterator iterator = this.getWorlds().iterator();
  
-@@ -1428,7 +1490,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -1438,7 +1500,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
              processQueue.remove().run();
          }
          MinecraftTimings.processQueueTimer.stopTiming(); // Spigot
@@ -11118,7 +11118,7 @@ index 0db00322ebf600245bf9311e547c8c743a60a173..02d8a8f13d81c47316f704fb700afd02
          MinecraftTimings.timeUpdateTimer.startTiming(); // Spigot // Paper
          // Send time updates to everyone, it will get the right time from the world the player is in.
          // Paper start - optimize time updates
-@@ -1471,11 +1533,16 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -1481,11 +1543,16 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
              this.methodProfiler.enter("tick");
  
              try {
@@ -11137,7 +11137,7 @@ index 0db00322ebf600245bf9311e547c8c743a60a173..02d8a8f13d81c47316f704fb700afd02
              } catch (Throwable throwable) {
                  // Spigot Start
                  CrashReport crashreport;
-@@ -1569,7 +1636,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -1579,7 +1646,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
      }
  
      public String getServerModName() {
@@ -11168,7 +11168,7 @@ index 52bb528e75eb43156ee2bf19877bc051a35bb6e3..d902efdb8f2d42ea4c3933f7fa76ebe1
  
          if (this.remoteControlListener != null) {
 diff --git a/src/main/java/net/minecraft/server/level/ChunkMapDistance.java b/src/main/java/net/minecraft/server/level/ChunkMapDistance.java
-index 2f8bca35508640f6b8c312fff17d55f129431599..db8532c42fcb2e96f4b3491352d1b9a25a8efe49 100644
+index 3644e8b24b082e17752ef52934625416130aaa08..ad90735b5daa658cdd5467eadcb29183d018b1fd 100644
 --- a/src/main/java/net/minecraft/server/level/ChunkMapDistance.java
 +++ b/src/main/java/net/minecraft/server/level/ChunkMapDistance.java
 @@ -40,9 +40,9 @@ public abstract class ChunkMapDistance {
@@ -11395,8 +11395,8 @@ index 2f8bca35508640f6b8c312fff17d55f129431599..db8532c42fcb2e96f4b3491352d1b9a2
 +    /* Tuinity - replace old loader system
      class c extends ChunkMapDistance.b {
  
-         private int e = 0;
-@@ -733,6 +788,7 @@ public abstract class ChunkMapDistance {
+         private int e = 0; private int getViewDistance() { return e; } private void setViewDistance(int value) { this.e = value; } // Paper - OBFHELPER
+@@ -737,6 +792,7 @@ public abstract class ChunkMapDistance {
              return i <= this.e - 2;
          }
      }

--- a/patches/server/0002-Airplane-Server-Changes.patch
+++ b/patches/server/0002-Airplane-Server-Changes.patch
@@ -1416,10 +1416,10 @@ index 8edc279e7a3fdfb7e10718f1deee34b7e3fb2f28..73ec17dea5d5668e49c9a6ad679bd3a3
          @Override
          public BlockPosition shift(EnumDirection enumdirection, int i) {
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 02d8a8f13d81c47316f704fb700afd0214a5f546..ca10d901ebd56bdee54f3c8cf607a5a34cd79f32 100644
+index 7b0b416c73c8914f3c8c570f2020490ef2babf64..246fcc9b40152964810ceef356ecb2eee3551135 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
-@@ -1636,7 +1636,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -1646,7 +1646,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
      }
  
      public String getServerModName() {

--- a/patches/server/0004-Rebrand.patch
+++ b/patches/server/0004-Rebrand.patch
@@ -92,10 +92,10 @@ index 3bc5cd1e53dd7c94b948e7f57f0dc8e073e349b0..87891161f5b06bb8be0e2016b490484e
                      throwable = throwable1;
                      throw throwable1;
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index ca10d901ebd56bdee54f3c8cf607a5a34cd79f32..4f602f0448585b95b8b2b05006f0fa9f9c57ba43 100644
+index 246fcc9b40152964810ceef356ecb2eee3551135..8620bbcc7c555e4760777397063f0392c9acc35e 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
-@@ -1636,7 +1636,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -1646,7 +1646,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
      }
  
      public String getServerModName() {

--- a/patches/server/0012-Configurable-server-mod-name.patch
+++ b/patches/server/0012-Configurable-server-mod-name.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Configurable server mod name
 
 
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 4f602f0448585b95b8b2b05006f0fa9f9c57ba43..ccccd3fffb9027469d545f586b15c045b5698b63 100644
+index 8620bbcc7c555e4760777397063f0392c9acc35e..83b98a18a8b726621068b5fd2bed046852dccf2d 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
-@@ -1636,7 +1636,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -1646,7 +1646,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
      }
  
      public String getServerModName() {

--- a/patches/server/0014-Lagging-threshold.patch
+++ b/patches/server/0014-Lagging-threshold.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Lagging threshold
 
 
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index ccccd3fffb9027469d545f586b15c045b5698b63..22ca3082fff5a630fe7d6a5ec1e70f5675a5a8bc 100644
+index 83b98a18a8b726621068b5fd2bed046852dccf2d..a75a8322829f36045243d5fd61d28b126af1f0af 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -279,6 +279,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
@@ -16,7 +16,7 @@ index ccccd3fffb9027469d545f586b15c045b5698b63..22ca3082fff5a630fe7d6a5ec1e70f56
      public final SlackActivityAccountant slackActivityAccountant = new SlackActivityAccountant();
      // Spigot end
  
-@@ -1104,6 +1105,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -1114,6 +1115,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
                          recentTps[1] = tps5.getAverage();
                          recentTps[2] = tps15.getAverage();
                          // Paper end

--- a/patches/server/0058-Configurable-TPS-Catchup.patch
+++ b/patches/server/0058-Configurable-TPS-Catchup.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Configurable TPS Catchup
 
 
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 22ca3082fff5a630fe7d6a5ec1e70f5675a5a8bc..9cc171e17e0d5d8f60a6d229eb2d39fb9181412f 100644
+index a75a8322829f36045243d5fd61d28b126af1f0af..ab2424a868a3d29af96f36ce037f1ab9b9b2a635 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
-@@ -1122,7 +1122,13 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -1132,7 +1132,13 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
                      this.a(this::canSleepForTick);
                      this.methodProfiler.exitEnter("nextTickWait");
                      this.X = true;

--- a/patches/server/0075-Add-5-second-tps-average-in-tps.patch
+++ b/patches/server/0075-Add-5-second-tps-average-in-tps.patch
@@ -27,7 +27,7 @@ index dc6bc1910ad0f9b27144d5750078c3ca607d03d3..e8be35f836ede2630d44902e99a21489
          setListData(vector);
      }
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 9cc171e17e0d5d8f60a6d229eb2d39fb9181412f..fd32bd05973785c4fc64849a8b7a96551a3223b9 100644
+index ab2424a868a3d29af96f36ce037f1ab9b9b2a635..cdddae4ff5178112d4523079144803f2694267d5 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -278,7 +278,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
@@ -39,7 +39,7 @@ index 9cc171e17e0d5d8f60a6d229eb2d39fb9181412f..fd32bd05973785c4fc64849a8b7a9655
      public boolean lagging = false; // Purpur
      public final SlackActivityAccountant slackActivityAccountant = new SlackActivityAccountant();
      // Spigot end
-@@ -1005,6 +1005,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -1015,6 +1015,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
      private static final long MAX_CATCHUP_BUFFER = TICK_TIME * TPS * 60L;
      private long lastTick = 0;
      private long catchupTime = 0;
@@ -47,7 +47,7 @@ index 9cc171e17e0d5d8f60a6d229eb2d39fb9181412f..fd32bd05973785c4fc64849a8b7a9655
      public final RollingAverage tps1 = new RollingAverage(60);
      public final RollingAverage tps5 = new RollingAverage(60 * 5);
      public final RollingAverage tps15 = new RollingAverage(60 * 15);
-@@ -1097,13 +1098,17 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -1107,13 +1108,17 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
                      {
                          final long diff = curTime - tickSection;
                          java.math.BigDecimal currentTps = TPS_BASE.divide(new java.math.BigDecimal(diff), 30, java.math.RoundingMode.HALF_UP);

--- a/patches/server/0104-Ridables.patch
+++ b/patches/server/0104-Ridables.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Ridables
 
 
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index fd32bd05973785c4fc64849a8b7a96551a3223b9..45cb8681fd0942084b56eb8d45390c2dbc8a4f3d 100644
+index cdddae4ff5178112d4523079144803f2694267d5..f6637353fb358e7720edabc355ea036d37d039ca 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
-@@ -1530,6 +1530,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -1540,6 +1540,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
              WorldServer worldserver = (WorldServer) iterator.next();
              worldserver.hasPhysicsEvent =  org.bukkit.event.block.BlockPhysicsEvent.getHandlerList().getRegisteredListeners().length > 0; // Paper
              worldserver.hasEntityMoveEvent =  EntityMoveEvent.getHandlerList().getRegisteredListeners().length > 0; // Paper

--- a/patches/server/0154-Implement-TPSBar.patch
+++ b/patches/server/0154-Implement-TPSBar.patch
@@ -17,10 +17,10 @@ index a551636c2c59e68a5abb1cd5611c1d5c7e36f514..b7663a3d64ae5202abb93eabba6ec013
  
          if (commanddispatcher_servertype.d) {
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 45cb8681fd0942084b56eb8d45390c2dbc8a4f3d..16c20b3e7dcbbdb08e8c2a15074495eacc001e70 100644
+index f6637353fb358e7720edabc355ea036d37d039ca..5e2c7f3bf9aa99b10260454b9957caff81a7cd26 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
-@@ -979,6 +979,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -989,6 +989,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
          this.safeShutdown(flag, false);
      }
      public void safeShutdown(boolean flag, boolean isRestarting) {


### PR DESCRIPTION
Upstream has released updates that appear to apply and compile correctly

Paper Changes:
a08be1ec7 [Auto] Updated Upstream (CraftBukkit)
606cdac60 Update the view distance before scheduling chunk loads (#5269)